### PR TITLE
Use runcommand for running the db commands

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -42,14 +42,7 @@ class CLI extends WP_CLI_Command
 	{
 		$backup_dir = untrailingslashit( Functions::tempdir( 'VAK' ) );
 
-		WP_CLI::launch_self(
-			"db export",
-			array( $backup_dir . "/wordpress.sql" ),
-			array(),
-			true,
-			true,
-			array( 'path' => WP_CLI::get_runner()->config['path'] )
-		);
+		WP_CLI::runcommand( "db export " . $backup_dir . "/wordpress.sql" );
 
 		file_put_contents(
 			$backup_dir . '/manifest.json',
@@ -107,14 +100,7 @@ class CLI extends WP_CLI_Command
 		Functions::rcopy( $tmp_dir . '/wordpress', ABSPATH, array() );
 
 		if ( is_file( $tmp_dir . "/wordpress.sql" ) ) {
-			$result = WP_CLI::launch_self(
-				"db import",
-				array( $tmp_dir . "/wordpress.sql" ),
-				array(),
-				true,
-				true,
-				array( 'path' => WP_CLI::get_runner()->config['path'] )
-			);
+			$result = WP_CLI::runcommand( "db import " . $tmp_dir . "/wordpress.sql" );
 			if ( $result->return_code ) {
 				Functions::rrmdir( $tmp_dir );
 				WP_CLI::error( sprintf( "Can't import database from '%s'.", $args[0] ) );


### PR DESCRIPTION
In the wp-cli 1.4.0 the backup and restore commands no longer work. I guess the issue is in the command that runs the `db export`.

The documentation recommends to use the `WP_CLI::runcommand()` instead of `WP_CLI::launch_self()`. ([Docs](1)) After changing the functions the backup and restore command works again.

[1]: https://make.wordpress.org/cli/handbook/internal-api/wp-cli-launch-self/#notes